### PR TITLE
Adding support for QueryRelationMixin

### DIFF
--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -1,4 +1,5 @@
 require 'query_relation/version'
+require 'query_relation/mixins/query_relation_mixin'
 
 require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/enumerable'

--- a/lib/query_relation/mixins/query_relation_mixin.rb
+++ b/lib/query_relation/mixins/query_relation_mixin.rb
@@ -1,0 +1,18 @@
+require 'active_support'
+require 'active_support/core_ext'
+
+module QueryRelationMixin
+  extend ActiveSupport::Concern
+
+  def all(*args)
+    QueryRelation.new(self, *args)
+  end
+
+  # TODO: ids, second, third, fourth, fifth, not, only, reverse_order
+
+  delegate :first, :last,
+           :select, :where,
+           :limit, :offset, :take,
+           :except, :unscope,
+           :order, :reorder, :to => :all
+end

--- a/lib/query_relation/mixins/query_relation_mixin.rb
+++ b/lib/query_relation/mixins/query_relation_mixin.rb
@@ -12,7 +12,10 @@ module QueryRelationMixin
 
   delegate :first, :last,
            :select, :where,
-           :limit, :offset, :take,
+           :limit, :offset,
+           :size, :length, :take, :each, :empty?, :presence,
            :except, :unscope,
+           :includes, :references,
+           :find, :count,
            :order, :reorder, :to => :all
 end


### PR DESCRIPTION
With this mixin, the QueryRelation can be easily included in Ruby classes. 

see https://github.com/ManageIQ/manageiq-api-client/pull/24 for an example.
