### PR TITLE
Proc interface

### DIFF
--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -41,9 +41,11 @@ class QueryRelation
   # - [X] where (partial)
   # - [ ] where.not
 
-  def initialize(model, opts = {})
+  def initialize(model, opts = nil, &block)
     @klass   = model
-    @options = opts || {}
+    @options = opts ? opts.dup : {}
+    query_method = @options.delete(:query_method) || :search
+    @target = block || ->(*args) { klass.send(query_method, *args) }
   end
 
   def where(*val)
@@ -172,12 +174,11 @@ class QueryRelation
   private
 
   def dup
-    self.class.new(klass, options.dup)
+    self.class.new(klass, options, &@target)
   end
 
   def call_query_method(mode)
-    query_method = options.fetch(:query_method, :search)
-    klass.send(query_method, mode, options.delete_blanks)
+    @target.call(mode, options.delete_blanks)
   end
 
   def append_hash_arg(symbol, *val)

--- a/lib/query_relation/queryable.rb
+++ b/lib/query_relation/queryable.rb
@@ -5,7 +5,7 @@ class QueryRelation
     extend Forwardable
 
     def all(*args)
-      QueryRelation.new(self, *args)
+      QueryRelation.new(self, *args) { |*params| search(*params) }
     end
 
     def_delegators :all,

--- a/spec/query_relation_spec.rb
+++ b/spec/query_relation_spec.rb
@@ -1,7 +1,31 @@
 describe QueryRelation do
   let(:model) { double("model") }
-  let(:query) { described_class.new(model) }
+  let(:query) { described_class.new(model) { |*params| model.search(*params) } }
   let(:query_method) { :search }
+
+  describe "#initialize" do
+    it "supports block" do
+      expect(model).not_to receive(:search)
+      block = -> (mode, opts) { [1, 2, 3] if mode == :all && opts == {:includes => [:a]} }
+
+      query = described_class.new(model,&block)
+      expect(query.includes(:a).to_a).to eq([1, 2, 3])
+    end
+
+    it "defaults to klass.search" do
+      expect(model).to receive(:search).with(:all, :includes => [:a]).and_return([1, 2, 3])
+
+      query = described_class.new(model)
+      expect(query.includes(:a).to_a).to eq([1, 2, 3])
+    end
+
+    it "supports :query_method" do
+      expect(model).to receive(:some_method).with(:all, :includes => [:a]).and_return([1, 2, 3])
+
+      query = described_class.new(model, :query_method => :some_method)
+      expect(query.includes(:a).to_a).to eq([1, 2, 3])
+    end
+  end
 
   describe "#except" do
     it "removes an expression" do
@@ -255,13 +279,6 @@ describe QueryRelation do
       my_query.to_a # executes/caches the results
       expect(my_query.to_a).to eq([1, 2, 3])
     end
-
-    it "with :query_method option" do
-      expect(model).to receive(:some_method).with(:all, :includes => [:a]).and_return([1, 2, 3])
-
-      query = described_class.new(model, :query_method => :some_method)
-      expect(query.includes(:a).to_a).to eq([1, 2, 3])
-    end
   end
 
   describe "#all" do
@@ -295,13 +312,6 @@ describe QueryRelation do
       my_query.to_a # executes/caches the results
       expect(my_query.first).to eq(1)
     end
-
-    it "with :query_method option" do # move
-      expect(model).to receive(:some_method).with(:first, :includes => [:a]).and_return(5)
-
-      query = described_class.new(model, :query_method => :some_method)
-      expect(query.includes(:a).first).to eq(5)
-    end
   end
 
   describe "#last" do
@@ -316,13 +326,6 @@ describe QueryRelation do
       my_query = query.includes(:a)
       my_query.to_a # executes/caches the results
       expect(my_query.last).to eq(3)
-    end
-
-    it "with :query_method option" do # move
-      expect(model).to receive(:some_method).with(:last, :includes => [:a]).and_return(5)
-
-      query = described_class.new(model, :query_method => :some_method)
-      expect(query.includes(:a).last).to eq(5)
     end
   end
 

--- a/spec/query_relation_spec.rb
+++ b/spec/query_relation_spec.rb
@@ -257,7 +257,7 @@ describe QueryRelation do
     end
 
     it "with :query_method option" do
-      expect(model).to receive(:some_method).with(:all, :includes => [:a], :query_method => :some_method).and_return([1, 2, 3])
+      expect(model).to receive(:some_method).with(:all, :includes => [:a]).and_return([1, 2, 3])
 
       query = described_class.new(model, :query_method => :some_method)
       expect(query.includes(:a).to_a).to eq([1, 2, 3])
@@ -296,8 +296,8 @@ describe QueryRelation do
       expect(my_query.first).to eq(1)
     end
 
-    it "with :query_method option" do
-      expect(model).to receive(:some_method).with(:first, :includes => [:a], :query_method => :some_method).and_return(5)
+    it "with :query_method option" do # move
+      expect(model).to receive(:some_method).with(:first, :includes => [:a]).and_return(5)
 
       query = described_class.new(model, :query_method => :some_method)
       expect(query.includes(:a).first).to eq(5)
@@ -318,8 +318,8 @@ describe QueryRelation do
       expect(my_query.last).to eq(3)
     end
 
-    it "with :query_method option" do
-      expect(model).to receive(:some_method).with(:last, :includes => [:a], :query_method => :some_method).and_return(5)
+    it "with :query_method option" do # move
+      expect(model).to receive(:some_method).with(:last, :includes => [:a]).and_return(5)
 
       query = described_class.new(model, :query_method => :some_method)
       expect(query.includes(:a).last).to eq(5)


### PR DESCRIPTION
Instead of hardcoding the name of the search method, pass in a block.
- This separates the search interface from the `klass` implementation.
- This also allows features like `legacy_options` to be easily integrated.
- This removes the `:query_method` value from leaking through to the `search` method.

nit: Left in the fallback to `klass.search` and `klass.send(query_method)` (from `options[:query_method]` but wanted to remove them.
