### PR TITLE
Proc interface 2

### DIFF
--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -42,9 +42,10 @@ class QueryRelation
   # - [X] where (partial)
   # - [ ] where.not
 
-  def initialize(model, opts = nil)
+  def initialize(model, opts = nil, &block)
     @klass   = model
     @options = opts ? opts.dup : {}
+    @target = block || ->(*args) { klass.search(*args) }
   end
 
   def where(*val)
@@ -173,12 +174,11 @@ class QueryRelation
   private
 
   def dup
-    self.class.new(klass, options)
+    self.class.new(klass, options, &@target)
   end
 
   def call_query_method(mode)
-    query_method = options.fetch(:query_method, :search)
-    klass.send(query_method, mode, options.delete_blanks)
+    @target.call(mode, options.delete_blanks)
   end
 
   def append_hash_arg(symbol, *val)

--- a/lib/query_relation/queryable.rb
+++ b/lib/query_relation/queryable.rb
@@ -5,7 +5,7 @@ class QueryRelation
     extend Forwardable
 
     def all(*args)
-      QueryRelation.new(self, *args)
+      QueryRelation.new(self, *args) { |*params| search(*params) }
     end
 
     def_delegators :all,


### PR DESCRIPTION
After discussing this a little, I like this better than #5 

default interface is to use `search`
Alternatively, you can pass in a block for search.

Coded this up because it is quicker to throw this together than setup a meeting.
And this isn't so dire that it requires a meeting
