### PR TITLE
Queryable interface supports private search method

### DIFF
--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -45,7 +45,7 @@ class QueryRelation
   def initialize(model, opts = nil, &block)
     @klass   = model
     @options = opts ? opts.dup : {}
-    @target = block || ->(*args) { klass.search(*args) }
+    @target = block || ->(*args) { klass.send(:search, *args) }
   end
 
   def where(*val)

--- a/lib/query_relation/queryable.rb
+++ b/lib/query_relation/queryable.rb
@@ -5,7 +5,7 @@ class QueryRelation
     extend Forwardable
 
     def all(*args)
-      QueryRelation.new(self, *args) { |*params| search(*params) }
+      QueryRelation.new(self, *args)
     end
 
     def_delegators :all,

--- a/spec/queryable_spec.rb
+++ b/spec/queryable_spec.rb
@@ -11,6 +11,7 @@ describe QueryRelation::Queryable do
         when :last  then records.last
         end
       end
+      private_class_method :search
     end
   end
 


### PR DESCRIPTION
We want to have `search` be a private method. This allows the block to
call a private method

(This fixes the manageiq build.)
