### PR TITLE
Add a default filter_collection method

### DIFF
--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -171,6 +171,17 @@ class QueryRelation
     true
   end
 
+  # Default filter for a +collection+ based on various +options+ that are used
+  # by QueryRelation. Classes that include/extend this module can redefine it
+  # as they see fit.
+  #
+  def filter_collection(collection, options)
+    collection = collection.drop(options[:offset]) if options[:offset]
+    collection = collection.take(options[:limit]) if options[:limit]
+    collection = collection.select{ |hash| hash.slice(*options[:where].keys) == options[:where] } if options[:where]
+    collection
+  end
+
   private
 
   def dup


### PR DESCRIPTION
As per https://github.com/ManageIQ/manageiq/pull/19677#issuecomment-570305320, let's add a default `filter_collection` method that users can take advantage of if they don't need anything fancy.

Draft for now while I add some more logic and figure out a couple things and write some specs.