### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Provides an ActiveRecord::Relation-like DSL to non-SQL backends
 [![Code Climate](https://codeclimate.com/github/ManageIQ/query_relation/badges/gpa.svg)](https://codeclimate.com/github/ManageIQ/query_relation)
 [![Codacy](https://api.codacy.com/project/badge/grade/9ffce48ccb924020ae8f9e698048e9a4)](https://www.codacy.com/app/ManageIQ/query_relation)
 [![Coverage Status](https://coveralls.io/repos/ManageIQ/query_relation/badge.svg?branch=master&service=github)](https://coveralls.io/github/ManageIQ/query_relation?branch=master)
-[![Dependency Status](https://gemnasium.com/ManageIQ/query_relation.svg)](https://gemnasium.com/ManageIQ/query_relation)
 [![Security](https://hakiri.io/github/ManageIQ/query_relation/master.svg)](https://hakiri.io/github/ManageIQ/query_relation/master)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Provides an ActiveRecord::Relation-like DSL to non-SQL backends
 
 [![Gem Version](https://badge.fury.io/rb/query_relation.svg)](http://badge.fury.io/query_relation)
-[![Build Status](https://travis-ci.org/ManageIQ/query_relation.svg)](https://travis-ci.org/ManageIQ/query_relation)
+[![Build Status](https://travis-ci.com/ManageIQ/query_relation.svg)](https://travis-ci.com/ManageIQ/query_relation)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/query_relation/badges/gpa.svg)](https://codeclimate.com/github/ManageIQ/query_relation)
 [![Codacy](https://api.codacy.com/project/badge/grade/9ffce48ccb924020ae8f9e698048e9a4)](https://www.codacy.com/app/ManageIQ/query_relation)
 [![Coverage Status](https://coveralls.io/repos/ManageIQ/query_relation/badge.svg?branch=master&service=github)](https://coveralls.io/github/ManageIQ/query_relation?branch=master)


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.

Also, fixed link from travis-ci.org to travis-ci.com