### PR TITLE
remove sudo from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: bionic
-sudo: false
 language: ruby
 rvm:
 - 2.5.7


### PR DESCRIPTION
remove sudo per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration: `If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.`

@miq-bot add_label cleanup
@miq-bot add_label developer 
@miq-bot assign @kbrock