### PR TITLE
remove distro from travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: bionic
 language: ruby
 rvm:
 - 2.5.7


### PR DESCRIPTION
Per https://github.com/ManageIQ/manageiq/pull/20690#issuecomment-708484319 I expect that listing the distro on this repo isn’t necessary and we should only do so when it’s required. I don't really think that's here, and this isn't the default anyway. 


the bot isn’t going to run here, so could whoever sees this please tag and assign for me? 
@miq-bot add_label cleanup
@miq-bot assign @kbrock