### PR TITLE
Drop More core extensions and active_support

### DIFF
--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -2,7 +2,6 @@ require 'query_relation/version'
 require 'query_relation/queryable'
 
 require 'active_support'
-require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/object/blank'
 
@@ -59,7 +58,7 @@ class QueryRelation
       elsif old_where.kind_of?(Hash) && val.kind_of?(Hash)
         val.each_pair do |key, value|
           old_where[key] = if old_where[key]
-                             Array.wrap(old_where[key]) + Array.wrap(value)
+                             Array(old_where[key]) + Array(value)
                            else
                              value
                            end

--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -3,7 +3,6 @@ require 'query_relation/queryable'
 
 require 'active_support'
 require 'active_support/core_ext/enumerable'
-require 'active_support/core_ext/object/blank'
 
 require 'forwardable'
 
@@ -51,9 +50,9 @@ class QueryRelation
     val = val.first if val.size == 1 && val.first.kind_of?(Hash)
     dup.tap do |r|
       old_where = r.options[:where]
-      if val.blank?
+      if val.nil? || val.empty?
         # nop
-      elsif old_where.blank?
+      elsif old_where.nil? || old_where.empty?
         r.options[:where] = val
       elsif old_where.kind_of?(Hash) && val.kind_of?(Hash)
         val.each_pair do |key, value|
@@ -155,6 +154,10 @@ class QueryRelation
 
   def_delegators :to_a, :size, :length, :take, :each, :empty?, :presence
 
+  def blank?
+    to_a.nil? || to_a.empty?
+  end
+
   # TODO: support arguments
   def first
     defined?(@results) ? @results.first : call_query_method(:first)
@@ -201,9 +204,9 @@ class QueryRelation
   # @param b [Array, Hash]
   # @param default default value for conversion to a hash. e.g.: {} or "ASC"
   def merge_hash_or_array(a, b, default = {})
-    if a.blank?
+    if a.nil? || a.empty?
       b
-    elsif b.blank?
+    elsif b.nil? || b.empty?
       a
     elsif a.kind_of?(Array) && b.kind_of?(Array)
       a + b

--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -1,9 +1,6 @@
 require 'query_relation/version'
 require 'query_relation/queryable'
 
-require 'active_support'
-require 'active_support/core_ext/enumerable'
-
 require 'forwardable'
 
 class QueryRelation
@@ -152,10 +149,18 @@ class QueryRelation
     to_a.size
   end
 
-  def_delegators :to_a, :size, :length, :take, :each, :empty?, :presence
+  def_delegators :to_a, :size, :length, :take, :each, :empty?
+
+  def presence
+    to_a if present?
+  end
 
   def blank?
     to_a.nil? || to_a.empty?
+  end
+
+  def present?
+    !blank?
   end
 
   # TODO: support arguments

--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -6,8 +6,6 @@ require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/object/blank'
 
-require 'more_core_extensions/core_ext/hash/deletes'
-
 require 'forwardable'
 
 class QueryRelation
@@ -179,7 +177,7 @@ class QueryRelation
   end
 
   def call_query_method(mode)
-    @target.call(mode, options.delete_blanks)
+    @target.call(mode, options.delete_if { |_n, v| v.nil? || (v.respond_to?(:empty?) && v.empty?) })
   end
 
   def append_hash_arg(symbol, *val)

--- a/query_relation.gemspec
+++ b/query_relation.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "more_core_extensions"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "manageiq-style"

--- a/query_relation.gemspec
+++ b/query_relation.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
-
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"

--- a/spec/query_relation_spec.rb
+++ b/spec/query_relation_spec.rb
@@ -382,23 +382,6 @@ describe QueryRelation do
     end
   end
 
-  describe "#many?" do
-    it "returns true when many results are returned" do
-      expect(model).to receive(query_method).with(:all, {}).and_return([1, 2])
-      expect(query.many?).to be true
-    end
-
-    it "returns false when 1 result is returned" do
-      expect(model).to receive(query_method).with(:all, {}).and_return([1])
-      expect(query.many?).to be false
-    end
-
-    it "returns false when no results are returned" do
-      expect(model).to receive(query_method).with(:all, {}).and_return([])
-      expect(query.many?).to be false
-    end
-  end
-
   describe "#present?" do
     it "returns false when results are returned" do
       expect(model).to receive(query_method).with(:all, {}).and_return([1, 2])


### PR DESCRIPTION
Overview
========

This removes the active_support dependency
There are no longer any dependencies

Implications
============

Dropping active_support means that methods like `second`, `fourth`, and `many?` are no longer available.

I did add `presence`, `blank?` and `present?` since they are trivial implementation and often used.

The user the active support methods back back by requiring active support:

```
require 'active_support/core_ext/enumerable'
```

Goal
====

This along with dropping `active_support` from the manageiq-api-client gem cut dependencies by over half. see also ManageIQ/manageiq-api-client#115.

/cc @agrare 