### PR TITLE
Add support for pluck and to_a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ## [0.1.2]
+### Fixed
+- `Model#pluck` now passes `:select` [#34](https://github.com/ManageIQ/query_relation/pull/34)
+
+### Added
+- Support for `Model.to_a` [#34](https://github.com/ManageIQ/query_relation/pull/34)
+
 ### Changed
 - Dropped dependencies: more_core_extensions and active_support. [#31](https://github.com/ManageIQ/query_relation/pull/31)
 

--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -52,6 +52,7 @@ class QueryRelation
       elsif old_where.nil? || old_where.empty?
         r.options[:where] = val
       elsif old_where.kind_of?(Hash) && val.kind_of?(Hash)
+        old_where = r.options[:where] = r.options[:where].dup
         val.each_pair do |key, value|
           old_where[key] = if old_where[key]
                              Array(old_where[key]) + Array(value)
@@ -64,6 +65,10 @@ class QueryRelation
               "Need to support #{__callee__}(#{val.class.name}) with existing #{old_where.class.name}"
       end
     end
+  end
+
+  def where_values
+    options[:where]
   end
 
   def includes(*args)

--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -104,9 +104,7 @@ class QueryRelation
       raise ArgumentError, "Need to support #{__callee__}(#{columns.class.name})"
     end
 
-    dup.tap do |r|
-      r.options[:order] = columns
-    end
+    assign_arg(:order, columns)
   end
 
   # @param val [Array<Symbol>, Symbol] attributes to remove from the query

--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -142,6 +142,20 @@ class QueryRelation
     append_hash_arg :select, *columns
   end
 
+  # @param columns [Array<Sting,Symbol>,String, Symbol] columns to bring back
+  def pluck(*columns)
+    columns = columns.flatten.compact
+
+    val = assign_arg(:select, columns).to_a
+
+    if columns.size == 1
+      column = columns.first
+      val.map { |row| row[column] }
+    else
+      val.map { |row| columns.map { |col| row[col] } }
+    end
+  end
+
   def to_a
     @results ||= call_query_method(:all)
   end

--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -74,6 +74,7 @@ class QueryRelation
     append_hash_array_arg :references, {}, *args
   end
 
+  # @param val [Integer] maximum number of rows to bring back
   def limit(val)
     assign_arg :limit, val
   end
@@ -82,29 +83,33 @@ class QueryRelation
     options[:limit]
   end
 
-  def order(*args)
-    append_hash_array_arg :order, "ASC", *args
+  # @param columns [Array<Symbol>, Symbol] columns for order
+  def order(*columns)
+    append_hash_array_arg :order, "ASC", *columns
   end
 
   def order_values
     options[:order] || []
   end
 
-  def group(*args)
-    append_hash_arg :group, *args
+  # @param columns [Array<Symbol>, Symbol] columns for order, replacing original
+  def group(*columns)
+    append_hash_arg :group, *columns
   end
 
-  def reorder(*val)
-    val = val.flatten.compact
-    if val.first.kind_of?(Hash)
-      raise ArgumentError, "Need to support #{__callee__}(#{val.class.name})"
+  # @param columns [Array<Symbol>, Symbol] columns for order, replacing original
+  def reorder(*columns)
+    columns = columns.flatten.compact
+    if columns.first.kind_of?(Hash)
+      raise ArgumentError, "Need to support #{__callee__}(#{columns.class.name})"
     end
 
     dup.tap do |r|
-      r.options[:order] = val
+      r.options[:order] = columns
     end
   end
 
+  # @param val [Array<Symbol>, Symbol] attributes to remove from the query
   def except(*val)
     dup.tap do |r|
       val.flatten.compact.each do |key|
@@ -113,6 +118,7 @@ class QueryRelation
     end
   end
 
+  # @param val [Array<Symbol>, Symbol] attributes to remove from the query
   # similar to except. difference being this persists across merges
   def unscope(*val)
     dup.tap do |r|
@@ -122,6 +128,7 @@ class QueryRelation
     end
   end
 
+  # @param val [Integer] offset
   def offset(val)
     assign_arg :offset, val
   end
@@ -130,9 +137,9 @@ class QueryRelation
     options[:offset]
   end
 
-  # @param val [Array<Sting,Symbol>,String, Symbol]
-  def select(*args)
-    append_hash_arg :select, *args
+  # @param columns [Array<Sting, Symbol>, String, Symbol] columns to bring back
+  def select(*columns)
+    append_hash_arg :select, *columns
   end
 
   def to_a

--- a/lib/query_relation/queryable.rb
+++ b/lib/query_relation/queryable.rb
@@ -22,6 +22,7 @@ class QueryRelation
                    :first,
                    :last,
                    :take,
+                   :pluck,
                    :count
   end
 end

--- a/lib/query_relation/queryable.rb
+++ b/lib/query_relation/queryable.rb
@@ -22,6 +22,7 @@ class QueryRelation
                    :first,
                    :last,
                    :take,
+                   :to_a,
                    :pluck,
                    :count
   end

--- a/spec/query_relation_spec.rb
+++ b/spec/query_relation_spec.rb
@@ -84,6 +84,11 @@ describe QueryRelation do
   describe "#limit_value" do
     it { expect(query.limit_value).to eq(nil) }
     it { expect(query.limit(5).limit_value).to eq(5) }
+
+    it "leaves originals alone" do
+      query.limit(5)
+      expect(query.limit_value).to eq(nil)
+    end
   end
 
   # - [.] none
@@ -103,6 +108,11 @@ describe QueryRelation do
   describe "#offset_value" do
     it { expect(query.offset_value).to eq(nil) }
     it { expect(query.offset(5).offset_value).to eq(5) }
+
+    it "leaves originals alone" do
+      query.offset(5)
+      expect(query.offset_value).to eq(nil)
+    end
   end
 
   describe "#order" do
@@ -140,6 +150,14 @@ describe QueryRelation do
   describe "#order_values" do
     it { expect(query.order_values).to eq([]) }
     it { expect(query.order(:a).order(:b).order_values).to eq([:a, :b]) }
+
+    it "leaves originals alone" do
+      orig_query = query.order(:a)
+      expect(query.order_values).to eq([])
+
+      orig_query.order(:b)
+      expect(orig_query.order_values).to eq([:a])
+    end
   end
 
   describe "#references" do

--- a/spec/query_relation_spec.rb
+++ b/spec/query_relation_spec.rb
@@ -275,6 +275,20 @@ describe QueryRelation do
     it "does not merge hashes and strings" do
       expect { query.where(:a => :c).where("b = 5") }.to raise_error(ArgumentError)
     end
+
+    it "leaves original alone" do
+      orig_query = query.where(:a => 5, :b => 6)
+      orig_query.where(:a => 55, :b => 66)
+
+      expect(query.where_values).to eq(nil)
+      expect(orig_query.where_values).to eq({:a => 5, :b => 6})
+    end
+  end
+
+  describe "#where_values" do
+    it { expect(query.where_values).to eq(nil) }
+    it { expect(query.where(:a => 5, :b => 6).where_values).to eq(:a => 5, :b => 6) }
+    it { expect(query.where(:a => 5, :b => 6).where(:a => 55, :b => 66).where_values).to eq(:a => [5, 55], :b => [6, 66]) }
   end
 
   describe "#to_a" do

--- a/spec/query_relation_spec.rb
+++ b/spec/query_relation_spec.rb
@@ -426,4 +426,30 @@ describe QueryRelation do
       expect(result).to eq([1, 2, 3, 4, 5])
     end
   end
+
+  describe "#pluck" do
+    it "passes select (single)" do
+      expect(model).to receive(query_method).with(:all, {:select => [:a]}).and_return([{:a => 1}, {:a => 2}, {:a => 3}])
+      result = query.pluck(:a)
+      expect(result).to eq([1, 2, 3])
+    end
+
+    it "passes select (multi)" do
+      expect(model).to receive(query_method).with(:all, {:select => [:a, :b]}).and_return([{:a => 1, :b => 11}, {:a => 2, :b => 22}, {:a => 3, :b => 33}])
+      result = query.pluck(:a, :b)
+      expect(result).to eq([[1, 11], [2, 22], [3, 33]])
+    end
+
+    it "passes where" do
+      expect(model).to receive(query_method).with(:all, {:select => [:a], :where => {:a => 1}}).and_return([{:a => 1}])
+      result = query.where(:a => 1).pluck(:a)
+      expect(result).to eq([1])
+    end
+
+    it "supports no pluck parameters" do
+      expect(model).to receive(query_method).with(:all, {}).and_return([{:a => 1, :b => 11}, {:a => 2, :b => 22}, {:a => 3, :b => 33}])
+      result = query.select(:a, :b).pluck
+      expect(result).to eq([[], [], []])
+    end
+  end
 end

--- a/spec/queryable_spec.rb
+++ b/spec/queryable_spec.rb
@@ -4,7 +4,7 @@ describe QueryRelation::Queryable do
       extend QueryRelation::Queryable
 
       def self.search(mode, _options = {})
-        records = [1, 2, 3]
+        records = [{:a => 1, :b => 11}, {:a => 2, :b => 22}, {:a => 3, :b => 33}]
         case mode
         when :all   then records
         when :first then records.first
@@ -18,7 +18,7 @@ describe QueryRelation::Queryable do
   it ".all" do
     relation = model.all
     expect(relation).to be_kind_of(QueryRelation)
-    expect(relation.to_a).to eq([1, 2, 3])
+    expect(relation.to_a).to eq([{:a => 1, :b => 11}, {:a => 2, :b => 22}, {:a => 3, :b => 33}])
   end
 
   it ".select" do
@@ -82,15 +82,15 @@ describe QueryRelation::Queryable do
   end
 
   it ".first" do
-    expect(model.first).to eq(1)
+    expect(model.first).to eq({:a => 1, :b => 11})
   end
 
   it ".last" do
-    expect(model.last).to eq(3)
+    expect(model.last).to eq({:a => 3, :b => 33})
   end
 
   it ".take" do
-    expect(model.take(2)).to eq([1, 2])
+    expect(model.take(2)).to eq([{:a => 1, :b => 11}, {:a => 2, :b => 22}])
   end
 
   it ".count" do

--- a/spec/queryable_spec.rb
+++ b/spec/queryable_spec.rb
@@ -81,6 +81,10 @@ describe QueryRelation::Queryable do
     expect(relation.options).to eq(:order => [:b])
   end
 
+  it ".to_a" do
+    expect(model.to_a).to eq([{:a => 1, :b => 11}, {:a => 2, :b => 22}, {:a => 3, :b => 33}])
+  end
+
   it ".first" do
     expect(model.first).to eq({:a => 1, :b => 11})
   end
@@ -93,11 +97,11 @@ describe QueryRelation::Queryable do
     expect(model.pluck(:a)).to eq([1, 2, 3])
   end
 
-  it ".take" do
+  it ".take (enumerable)" do
     expect(model.take(2)).to eq([{:a => 1, :b => 11}, {:a => 2, :b => 22}])
   end
 
-  it ".count" do
+  it ".count (enumerable)" do
     expect(model.count).to eq(3)
   end
 end

--- a/spec/queryable_spec.rb
+++ b/spec/queryable_spec.rb
@@ -89,6 +89,10 @@ describe QueryRelation::Queryable do
     expect(model.last).to eq({:a => 3, :b => 33})
   end
 
+  it ".pluck" do
+    expect(model.pluck(:a)).to eq([1, 2, 3])
+  end
+
   it ".take" do
     expect(model.take(2)).to eq([{:a => 1, :b => 11}, {:a => 2, :b => 22}])
   end


### PR DESCRIPTION
You could consider this a bug or an enhancement

Before
======

- `Model.pluck(:a)` was essentially `Model.select("*").to_a.pluck(:a)` -- all fields brought back.

After
=====

- `Model.pluck(:a)` is essentially `Model.select(:a).to_a.pluck(:a)` -- only 1 column brought back.

Extra
=====

- added `Model.to_a`
- added tests ensuring chaining doesn't modify previous step
- added `Model#where_values`
- added yarddoc `@params` for many methods
- fix `where().where()`. It now doesn't modify the intermediate query.
