### PR TITLE
Backwards compatibility between references/includes and eager_load/preload

### DIFF
--- a/lib/query_relation.rb
+++ b/lib/query_relation.rb
@@ -12,20 +12,22 @@ class QueryRelation
   # - [ ] bind
   # - [ ] create_with
   # - [ ] distinct
-  # - [ ] eager_load
+  # - [X] eager_load (partial - leveraging references)
   # - [X] except ? - is this not defined in the interface?
   # - [ ] extending
   # - [ ] from
   # - [X] group
   # - [ ] ~~having~~ - NO
   # - [X] includes (partial)
-  # - [ ] joins
+  # - [X] joins (partial - references includes)
+  # - [ ] left_joins
+  # - [ ] left_outer_joins
   # - [X] limit
   # - [ ] lock
   # - [.] none
   # - [X] offset
   # - [X] order (partial)
-  # - [ ] preload
+  # - [X] preload (partial - leveraging includes)
   # - [ ] readonly
   # - [X] references (partial)
   # - [X] reorder
@@ -75,9 +77,22 @@ class QueryRelation
     append_hash_array_arg :includes, {}, *args
   end
 
+  def includes_values
+    options[:includes] || []
+  end
+
+  alias preload includes
+  alias preload_values includes_values
+
   def references(*args)
     append_hash_array_arg :references, {}, *args
   end
+
+  def references_values
+    options[:references] || []
+  end
+
+  alias joins references
 
   # @param val [Integer] maximum number of rows to bring back
   def limit(val)
@@ -111,6 +126,10 @@ class QueryRelation
 
     assign_arg(:order, columns)
   end
+
+  # similar to references, except takes typical hash and doesn't require includes entry
+  alias eager_load references
+  alias eager_load_values references_values
 
   # @param val [Array<Symbol>, Symbol] attributes to remove from the query
   def except(*val)

--- a/spec/query_relation_spec.rb
+++ b/spec/query_relation_spec.rb
@@ -20,6 +20,13 @@ describe QueryRelation do
     end
   end
 
+  describe "#eager_load" do
+    it "leverages references" do
+      expect(model).to receive(query_method).with(:all, {:references => [:a]})
+      query.eager_load(:a).to_a
+    end
+  end
+
   describe "#except" do
     it "removes an expression" do
       expect(model).to receive(query_method).with(:all, {:limit => 5}).and_return([1, 2, 3, 4, 5])
@@ -160,6 +167,16 @@ describe QueryRelation do
     end
   end
 
+  describe "#preload" do
+    it "leverages includes" do
+      expect(model).to receive(query_method).with(:all, {:includes => {:a => {}, :b => {}}})
+      x = query.preload(:a).preload(:b => {})
+      x.to_a
+    end
+  end
+
+  # NOTE: references don't take the hash. they take an array.
+  # we are going towards eager_load (which does take a hash), so leaving broken
   describe "#references" do
     it "chains array hash" do
       expect(model).to receive(query_method).with(:all, {:references => {:a => {}, :b => {}}})


### PR DESCRIPTION
We are moving from includes/references to preload/eager_load.

This supports both and treats them interchangeably.

Yes, they are a little different, but as far as we are concerned, they are close enough.
The API only supports includes and references, so no change there.

Tangent
=======

A pre-existing "bug"/"feature":

`references(args)` doesn't follow AR, as `args` in AR is an array of table names and in our implementation is a nested hash of AR references.

Since `eager_load(args)` for both AR and our interface are a nested hash of AR references, we work just fine - leaving the `references` bug, but our api doesn't really support that interface anyway.